### PR TITLE
Create constants for all of the defined modelNames.

### DIFF
--- a/iAppInfos/iAppInfos/iAppInfos/AppInformationsManager.m
+++ b/iAppInfos/iAppInfos/iAppInfos/AppInformationsManager.m
@@ -110,12 +110,12 @@
 
 - (NSString *)yourDeviceModel
 {
-    return [UIDevice modelName];
+    return [UIDevice jmo_modelName];
 }
 
 - (NSString *)compilationSDK
 {
-    return [UIApplication iOSSDKVersion];
+    return [UIApplication jmo_iOSSDKVersion];
 }
 
 - (NSString *)version
@@ -177,7 +177,7 @@
                 NSRange range = NSMakeRange(range1.location, range2.location + range2.length - range1.location);
                 result = [profileText substringWithRange:range];
                 
-                NSDictionary *dict = [NSDictionary dictionaryWithMobileProvisioningString:result];
+                NSDictionary *dict = [NSDictionary jmo_dictionaryWithMobileProvisioningString:result];
                 JMOMobileProvisionning *provisionningObj = [[JMOMobileProvisionning alloc] initWithDictionary:dict];
                 return provisionningObj;
             }

--- a/iAppInfos/iAppInfos/iAppInfos/NSDictionary+iAppInfos.h
+++ b/iAppInfos/iAppInfos/iAppInfos/NSDictionary+iAppInfos.h
@@ -10,6 +10,6 @@
 
 @interface NSDictionary (iAppInfos)
 
-+ (NSDictionary *)dictionaryWithMobileProvisioningString:(NSString *)RawMobileProvisionning;
++ (NSDictionary *)jmo_dictionaryWithMobileProvisioningString:(NSString *)RawMobileProvisionning;
 
 @end

--- a/iAppInfos/iAppInfos/iAppInfos/NSDictionary+iAppInfos.m
+++ b/iAppInfos/iAppInfos/iAppInfos/NSDictionary+iAppInfos.m
@@ -11,7 +11,7 @@
 
 @implementation NSDictionary (MobileProvisionningParser)
 
-+ (NSDictionary *)dictionaryWithMobileProvisioningString:(NSString *)RawMobileProvisionning
++ (NSDictionary *)jmo_dictionaryWithMobileProvisioningString:(NSString *)RawMobileProvisionning
 {
     NSMutableDictionary *dictionary =  [NSMutableDictionary new];
     NSArray* lines = [RawMobileProvisionning componentsSeparatedByCharactersInSet: [NSCharacterSet newlineCharacterSet]];

--- a/iAppInfos/iAppInfos/iAppInfos/UIApplication+iAppInfos.h
+++ b/iAppInfos/iAppInfos/iAppInfos/UIApplication+iAppInfos.h
@@ -10,6 +10,6 @@
 
 @interface UIApplication (iAppInfos)
 
-+ (NSString *)iOSSDKVersion;
++ (NSString *)jmo_iOSSDKVersion;
 
 @end

--- a/iAppInfos/iAppInfos/iAppInfos/UIApplication+iAppInfos.m
+++ b/iAppInfos/iAppInfos/iAppInfos/UIApplication+iAppInfos.m
@@ -11,7 +11,7 @@
 
 @implementation UIApplication (iAppInfos)
 
-+ (NSString *)iOSSDKVersion
++ (NSString *)jmo_iOSSDKVersion
 {
 #if defined(__IPHONE_7_0)
 //#warning "SDK7"

--- a/iAppInfos/iAppInfos/iAppInfos/UIDevice+iAppInfos.h
+++ b/iAppInfos/iAppInfos/iAppInfos/UIDevice+iAppInfos.h
@@ -8,8 +8,64 @@
 
 #import <UIKit/UIKit.h>
 
+extern NSString * const UIDeviceModeliPhone1G;
+extern NSString * const UIDeviceModeliPhone3G;
+extern NSString * const UIDeviceModeliPhone3GS;
+
+extern NSString * const UIDeviceModeliPhone4;
+extern NSString * const UIDeviceModelVerizoniPhone4;
+extern NSString * const UIDeviceModeliPhone4S;
+
+extern NSString * const UIDeviceModeliPhone5_GSM;
+extern NSString * const UIDeviceModeliPhone5_GSM_CDMA;
+extern NSString * const UIDeviceModeliPhone5C_GSM;
+extern NSString * const UIDeviceModeliPhone5C_Global;
+
+extern NSString * const UIDeviceModeliPhone5S_GSM;
+extern NSString * const UIDeviceModeliPhone5S_Global;
+
+extern NSString * const UIDeviceModeliPodTouch1G;
+extern NSString * const UIDeviceModeliPodTouch2G;
+extern NSString * const UIDeviceModeliPodTouch3G;
+extern NSString * const UIDeviceModeliPodTouch4G;
+extern NSString * const UIDeviceModeliPodTouch5G;
+
+extern NSString * const UIDeviceModeliPad;
+extern NSString * const UIDeviceModeliPad2_Wifi;
+extern NSString * const UIDeviceModeliPad2_GSM;
+extern NSString * const UIDeviceModeliPad2_CDMA;
+extern NSString * const UIDeviceModeliPad2;
+extern NSString * const UIDeviceModeliPad3G_Wifi;
+extern NSString * const UIDeviceModeliPad3G_4G;
+extern NSString * const UIDeviceModeliPad4G_Wifi;
+extern NSString * const UIDeviceModeliPad4G_GSM;
+extern NSString * const UIDeviceModeliPad4G_GSM_CDMA;
+
+extern NSString * const UIDeviceModeliPadMini1G_Wifi;
+extern NSString * const UIDeviceModeliPadMini1G_GSM;
+extern NSString * const UIDeviceModeliPadMini1G_GSM_CDMA;
+extern NSString * const UIDeviceModeliPadMiniRetina2G_Wifi;
+extern NSString * const UIDeviceModeliPadMiniRetina2G_Cellular;
+extern NSString * const UIDeviceModeliPadAir_Wifi;
+extern NSString * const UIDeviceModeliPadAir_Cellular;
+
+extern NSString * const UIDeviceModelSimulator;
+
+typedef NS_ENUM(NSInteger, UIDeviceModelType) {
+    UIDeviceModelTypeiPhone,
+    UIDeviceModelTypeiPod,
+    UIDeviceModelTypeiPad,
+    UIDeviceModelTypeSimulator
+};
+
 @interface UIDevice (iAppInfos)
 
-+ (NSString *)modelName;
++ (NSString *)jmo_modelName;
+
+/*!
+ * @return Whether the device is an iPod, iPhone, or iPad. If it is not explicitly any of those,
+ *  the device is assumed to be a simulator.
+ */
++ (UIDeviceModelType)jmo_deviceModelType;
 
 @end

--- a/iAppInfos/iAppInfos/iAppInfos/UIDevice+iAppInfos.m
+++ b/iAppInfos/iAppInfos/iAppInfos/UIDevice+iAppInfos.m
@@ -9,9 +9,53 @@
 #import "UIDevice+iAppInfos.h"
 #include <sys/sysctl.h>
 
+NSString * const UIDeviceModeliPhone1G                      = @"iPhone 1G";
+NSString * const UIDeviceModeliPhone3G                      = @"iPhone 3G";
+NSString * const UIDeviceModeliPhone3GS                     = @"iPhone 3GS";
+
+NSString * const UIDeviceModeliPhone4                       = @"iPhone 4";
+NSString * const UIDeviceModelVerizoniPhone4                = @"Verizon iPhone 4";
+NSString * const UIDeviceModeliPhone4S                      = @"iPhone 4S";
+
+NSString * const UIDeviceModeliPhone5_GSM                   = @"iPhone 5 (GSM)";
+NSString * const UIDeviceModeliPhone5_GSM_CDMA              = @"iPhone 5 (GSM+CDMA)";
+NSString * const UIDeviceModeliPhone5C_GSM                  = @"iPhone 5C (GSM)";
+NSString * const UIDeviceModeliPhone5C_Global               = @"iPhone 5C (Global)";
+
+NSString * const UIDeviceModeliPhone5S_GSM                  = @"iPhone 5S (GSM)";
+NSString * const UIDeviceModeliPhone5S_Global               = @"iPhone 5S (Global)";
+
+NSString * const UIDeviceModeliPodTouch1G                   = @"iPod Touch 1G";
+NSString * const UIDeviceModeliPodTouch2G                   = @"iPod Touch 2G";
+NSString * const UIDeviceModeliPodTouch3G                   = @"iPod Touch 3G";
+NSString * const UIDeviceModeliPodTouch4G                   = @"iPod Touch 4G";
+NSString * const UIDeviceModeliPodTouch5G                   = @"iPod Touch 5G";
+
+NSString * const UIDeviceModeliPad                          = @"iPad";
+NSString * const UIDeviceModeliPad2_Wifi                    = @"iPad 2 (WiFi)";
+NSString * const UIDeviceModeliPad2_GSM                     = @"iPad 2 (GSM)";
+NSString * const UIDeviceModeliPad2_CDMA                    = @"iPad 2 (CDMA)";
+NSString * const UIDeviceModeliPad2                         = @"iPad 2";
+NSString * const UIDeviceModeliPad3G_Wifi                   = @"iPad-3G (WiFi)";
+NSString * const UIDeviceModeliPad3G_4G                     = @"iPad-3G (4G)";
+NSString * const UIDeviceModeliPad4G_Wifi                   = @"iPad-4G (WiFi)";
+NSString * const UIDeviceModeliPad4G_GSM                    = @"iPad-4G (GSM)";
+NSString * const UIDeviceModeliPad4G_GSM_CDMA               = @"iPad-4G (GSM+CDMA)";
+
+NSString * const UIDeviceModeliPadMini1G_Wifi               = @"iPad mini-1G (WiFi)";
+NSString * const UIDeviceModeliPadMini1G_GSM                = @"iPad mini-1G (GSM)";
+NSString * const UIDeviceModeliPadMini1G_GSM_CDMA           = @"iPad mini-1G (GSM+CDMA)";
+NSString * const UIDeviceModeliPadMiniRetina2G_Wifi         = @"iPad mini 2G Retina (WiFi)";
+NSString * const UIDeviceModeliPadMiniRetina2G_Cellular     = @"iPad mini 2G Retina (Cellular)";
+NSString * const UIDeviceModeliPadAir_Wifi                  = @"iPad Air (WiFi)";
+NSString * const UIDeviceModeliPadAir_Cellular              = @"iPad Air (Cellular)";
+
+NSString * const UIDeviceModelSimulator                     = @"iPhone Simulator";
+
+
 @implementation UIDevice (iAppInfos)
 
-+ (NSString *) getSysInfo
++ (NSString *) jmo_getSysInfo
 {
     size_t size;
     sysctlbyname("hw.machine", NULL, &size, NULL, 0);
@@ -25,49 +69,102 @@
     return results;
 }
 
-+ (NSString *)modelName
++ (NSString *)jmo_modelName
 {
-    NSString *systInfo = [self getSysInfo];
-    if ([systInfo isEqualToString:@"iPhone1,1"])    return @"iPhone 1G";
-    if ([systInfo isEqualToString:@"iPhone1,2"])    return @"iPhone 3G";
-    if ([systInfo isEqualToString:@"iPhone2,1"])    return @"iPhone 3GS";
-    if ([systInfo isEqualToString:@"iPhone3,1"])    return @"iPhone 4";
-    if ([systInfo isEqualToString:@"iPhone3,3"])    return @"Verizon iPhone 4";
-    if ([systInfo isEqualToString:@"iPhone4,1"])    return @"iPhone 4S";
-    if ([systInfo isEqualToString:@"iPhone5,1"])    return @"iPhone 5 (GSM)";
-    if ([systInfo isEqualToString:@"iPhone5,2"])    return @"iPhone 5 (GSM+CDMA)";
-    if ([systInfo isEqualToString:@"iPhone5,3"])    return @"iPhone 5C (GSM)";
-    if ([systInfo isEqualToString:@"iPhone5,4"])    return @"iPhone 5C (Global)";
-    if ([systInfo isEqualToString:@"iPhone6,1"])    return @"iPhone 5S (GSM)";
-    if ([systInfo isEqualToString:@"iPhone6,2"])    return @"iPhone 5S (Global)";
-    if ([systInfo isEqualToString:@"iPod1,1"])      return @"iPod Touch 1G";
-    if ([systInfo isEqualToString:@"iPod2,1"])      return @"iPod Touch 2G";
-    if ([systInfo isEqualToString:@"iPod3,1"])      return @"iPod Touch 3G";
-    if ([systInfo isEqualToString:@"iPod4,1"])      return @"iPod Touch 4G";
-    if ([systInfo isEqualToString:@"iPod5,1"])      return @"iPod Touch 5G";
-    if ([systInfo isEqualToString:@"iPad1,1"])      return @"iPad";
-    if ([systInfo isEqualToString:@"iPad2,1"])      return @"iPad 2 (WiFi)";
-    if ([systInfo isEqualToString:@"iPad2,2"])      return @"iPad 2 (GSM)";
-    if ([systInfo isEqualToString:@"iPad2,3"])      return @"iPad 2 (CDMA)";
-    if ([systInfo isEqualToString:@"iPad2,4"])      return @"iPad 2";
-    if ([systInfo isEqualToString:@"iPad3,1"])      return @"iPad-3G (WiFi)";
-    if ([systInfo isEqualToString:@"iPad3,2"])      return @"iPad-3G (4G)";
-    if ([systInfo isEqualToString:@"iPad3,3"])      return @"iPad-3G (4G)";
-    if ([systInfo isEqualToString:@"iPad3,4"])      return @"iPad-4G (WiFi)";
-    if ([systInfo isEqualToString:@"iPad3,5"])      return @"iPad-4G (GSM)";
-    if ([systInfo isEqualToString:@"iPad3,6"])      return @"iPad-4G (GSM+CDMA)";
-    if ([systInfo isEqualToString:@"iPad2,5"])      return @"iPad mini-1G (WiFi)";
-    if ([systInfo isEqualToString:@"iPad2,6"])      return @"iPad mini-1G (GSM)";
-    if ([systInfo isEqualToString:@"iPad2,7"])      return @"iPad mini-1G (GSM+CDMA)";
-    if ([systInfo isEqualToString:@"iPad4,4"])      return @"iPad mini 2G Retina (WiFi)";
-    if ([systInfo isEqualToString:@"iPad4,5"])      return @"iPad mini 2G Retina (Cellular)";
-    if ([systInfo isEqualToString:@"iPad4,1"])      return @"iPad Air (WiFi)";
-    if ([systInfo isEqualToString:@"iPad4,2"])      return @"iPad Air (Cellular)";
+    NSString *systInfo = [self jmo_getSysInfo];
+    if ([systInfo isEqualToString:@"iPhone1,1"])    return UIDeviceModeliPhone1G;
+    if ([systInfo isEqualToString:@"iPhone1,2"])    return UIDeviceModeliPhone3G;
+    if ([systInfo isEqualToString:@"iPhone2,1"])    return UIDeviceModeliPhone3GS;
+    if ([systInfo isEqualToString:@"iPhone3,1"])    return UIDeviceModeliPhone4;
+    if ([systInfo isEqualToString:@"iPhone3,3"])    return UIDeviceModelVerizoniPhone4;
+    if ([systInfo isEqualToString:@"iPhone4,1"])    return UIDeviceModeliPhone4S;
+    if ([systInfo isEqualToString:@"iPhone5,1"])    return UIDeviceModeliPhone5_GSM;
+    if ([systInfo isEqualToString:@"iPhone5,2"])    return UIDeviceModeliPhone5_GSM_CDMA;
+    if ([systInfo isEqualToString:@"iPhone5,3"])    return UIDeviceModeliPhone5C_GSM;
+    if ([systInfo isEqualToString:@"iPhone5,4"])    return UIDeviceModeliPhone5C_Global;
+    if ([systInfo isEqualToString:@"iPhone6,1"])    return UIDeviceModeliPhone5S_GSM;
+    if ([systInfo isEqualToString:@"iPhone6,2"])    return UIDeviceModeliPhone5S_Global;
+    if ([systInfo isEqualToString:@"iPod1,1"])      return UIDeviceModeliPodTouch1G;
+    if ([systInfo isEqualToString:@"iPod2,1"])      return UIDeviceModeliPodTouch2G;
+    if ([systInfo isEqualToString:@"iPod3,1"])      return UIDeviceModeliPodTouch3G;
+    if ([systInfo isEqualToString:@"iPod4,1"])      return UIDeviceModeliPodTouch4G;
+    if ([systInfo isEqualToString:@"iPod5,1"])      return UIDeviceModeliPodTouch5G;
+    if ([systInfo isEqualToString:@"iPad1,1"])      return UIDeviceModeliPad;
+    if ([systInfo isEqualToString:@"iPad2,1"])      return UIDeviceModeliPad2_Wifi;
+    if ([systInfo isEqualToString:@"iPad2,2"])      return UIDeviceModeliPad2_GSM;
+    if ([systInfo isEqualToString:@"iPad2,3"])      return UIDeviceModeliPad2_CDMA;
+    if ([systInfo isEqualToString:@"iPad2,4"])      return UIDeviceModeliPad2;
+    if ([systInfo isEqualToString:@"iPad3,1"])      return UIDeviceModeliPad3G_Wifi;
+    if ([systInfo isEqualToString:@"iPad3,2"])      return UIDeviceModeliPad3G_4G;
+    if ([systInfo isEqualToString:@"iPad3,3"])      return UIDeviceModeliPad3G_4G;
+    if ([systInfo isEqualToString:@"iPad3,4"])      return UIDeviceModeliPad4G_Wifi;
+    if ([systInfo isEqualToString:@"iPad3,5"])      return UIDeviceModeliPad4G_GSM;
+    if ([systInfo isEqualToString:@"iPad3,6"])      return UIDeviceModeliPad4G_GSM_CDMA;
+    if ([systInfo isEqualToString:@"iPad2,5"])      return UIDeviceModeliPadMini1G_Wifi;
+    if ([systInfo isEqualToString:@"iPad2,6"])      return UIDeviceModeliPadMini1G_GSM;
+    if ([systInfo isEqualToString:@"iPad2,7"])      return UIDeviceModeliPadMini1G_GSM_CDMA;
+    if ([systInfo isEqualToString:@"iPad4,4"])      return UIDeviceModeliPadMiniRetina2G_Wifi;
+    if ([systInfo isEqualToString:@"iPad4,5"])      return UIDeviceModeliPadMiniRetina2G_Cellular;
+    if ([systInfo isEqualToString:@"iPad4,1"])      return UIDeviceModeliPadAir_Wifi;
+    if ([systInfo isEqualToString:@"iPad4,2"])      return UIDeviceModeliPadAir_Cellular;
     
-    return @"iPhone Simulator";
+    return UIDeviceModelSimulator;
 }
 
 
-
++ (UIDeviceModelType)jmo_deviceModelType {
+    NSString *modelName = [self jmo_modelName];
+    
+    NSArray *iphones = @[UIDeviceModeliPhone1G,
+                         UIDeviceModeliPhone3G,
+                         UIDeviceModeliPhone3GS,
+                         UIDeviceModeliPhone4,
+                         UIDeviceModelVerizoniPhone4,
+                         UIDeviceModeliPhone4S,
+                         UIDeviceModeliPhone5_GSM,
+                         UIDeviceModeliPhone5_GSM_CDMA,
+                         UIDeviceModeliPhone5C_GSM,
+                         UIDeviceModeliPhone5C_Global,
+                         UIDeviceModeliPhone5S_GSM,
+                         UIDeviceModeliPhone5S_Global];
+    if ([iphones containsObject:modelName]) {
+        return UIDeviceModelTypeiPhone;
+    }
+    
+    
+    NSArray *ipods = @[UIDeviceModeliPodTouch1G,
+                       UIDeviceModeliPodTouch2G,
+                       UIDeviceModeliPodTouch3G,
+                       UIDeviceModeliPodTouch4G,
+                       UIDeviceModeliPodTouch5G];
+    if ([ipods containsObject:modelName]) {
+        return UIDeviceModelTypeiPod;
+    }
+    
+         
+    NSArray *ipads = @[UIDeviceModeliPad,
+                       UIDeviceModeliPad2_Wifi,
+                       UIDeviceModeliPad2_GSM,
+                       UIDeviceModeliPad2_CDMA,
+                       UIDeviceModeliPad2,
+                       UIDeviceModeliPad3G_Wifi,
+                       UIDeviceModeliPad3G_4G,
+                       UIDeviceModeliPad3G_4G,
+                       UIDeviceModeliPad4G_Wifi,
+                       UIDeviceModeliPad4G_GSM,
+                       UIDeviceModeliPad4G_GSM_CDMA,
+                       UIDeviceModeliPadMini1G_Wifi,
+                       UIDeviceModeliPadMini1G_GSM,
+                       UIDeviceModeliPadMini1G_GSM_CDMA,
+                       UIDeviceModeliPadMiniRetina2G_Wifi,
+                       UIDeviceModeliPadMiniRetina2G_Cellular,
+                       UIDeviceModeliPadAir_Wifi,
+                       UIDeviceModeliPadAir_Cellular];
+    if ([ipads containsObject:modelName]) {
+        return UIDeviceModelTypeiPad;
+    }
+    
+    return UIDeviceModelTypeSimulator;
+}
 
 @end


### PR DESCRIPTION
Added deviceModelType to UIDevice category to return whether the device is an iPod, iPhone, iPad.
Prefixed category methods with jmo as per Apple documentation https://developer.apple.com/library/ios/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW4
