### PR TITLE
Update UIDevice+iAppInfos.m

### DIFF
--- a/iAppInfos/iAppInfos/iAppInfos/UIDevice+iAppInfos.m
+++ b/iAppInfos/iAppInfos/iAppInfos/UIDevice+iAppInfos.m
@@ -133,7 +133,10 @@ NSString * const UIDeviceModelSimulator                     = @"iPhone Simulator
 + (UIDeviceModelType)jmo_deviceModelType {
     NSString *modelName = [self jmo_modelName];
 
-    if ([modelName rangeOfString:@"iPhone"].location != NSNotFound) {
+    if ([modelName isEqualToString:UIDeviceModelSimulator]) {
+        return UIDeviceModelTypeSimulator;
+    }
+    else if ([modelName rangeOfString:@"iPhone"].location != NSNotFound) {
         return UIDeviceModelTypeiPhone;
     }
     else if ([modelName rangeOfString:@"iPod"].location != NSNotFound) {


### PR DESCRIPTION
When iPhone Simulator is returned as the modelName it falsely flags the UIDeviceModelType as an iPhone instead of a Simulator
